### PR TITLE
Revisions of main library function and split calls into separate file

### DIFF
--- a/example-function-calls.js
+++ b/example-function-calls.js
@@ -1,0 +1,15 @@
+//EXAMPLE call to attach to AddToCart action on website
+fbDynamicAdsPush(
+    'AddToCart',                    // populated manually: typed as string matching FB's documentation
+    'MYR',                          // populated dynamically: 3-letter currrency code as a string 'MYR' or 'USD' etc
+    210.40,                         // populated dynamically: interger or float of the total basket value
+    ['11234', '11112', '10982']     // populated dynamically: product IDs (or SKU's) associated with the event stored in an array
+);
+
+//EXAMPLE call to attach to Purchase action on website
+fbDynamicAdsPush(
+    'Purchase',                    // populated manually: typed as string matching FB's documentation
+    'MYR',                          // populated dynamically: 3-letter currrency code as a string 'MYR' or 'USD' etc
+    210.40,                         // populated dynamically: interger or float of the total basket value
+    ['11234', '11112', '10982']     // populated dynamically: product IDs (or SKU's) associated with the event stored in an array
+);

--- a/gtm-library-fb-datalayers.js
+++ b/gtm-library-fb-datalayers.js
@@ -1,27 +1,21 @@
-//references: https://developers.facebook.com/docs/analytics/send_data/events | https://developers.facebook.com/docs/facebook-pixel/implementation/dynamic-ads | https://developers.facebook.com/docs/facebook-pixel/implementation/conversion-tracking
-//Capitalised words are dynamic variables to be included
+// REFERENCES
 
-//required parameters for DYNAMIC ADS ONLY
-function pushTracking(VALUEOFBASKET, TYPE, SKU, QTY) {
-    console.log(TYPE);
+// https://developers.facebook.com/docs/analytics/send_data/events
+// https://developers.facebook.com/docs/facebook-pixel/implementation/dynamic-ads
+// https://developers.facebook.com/docs/facebook-pixel/implementation/conversion-tracking
+
+
+//BARE MINIMUM - required parameters for Facebook DYNAMIC ADS 
+function fbDynamicAdsPush(eventName, currencyXYZ, basketValue, arrayOfSKUs) {
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({
-        currency: 'MYR',
-        value: VALUEOFBASKET, //interger or float
-        content_ids: [SKU, SKU], //Product IDs associated with the event, such as SKUs (e.g. ['ABC123', 'XYZ789']). Can be an array.
-        content_type: TYPE, //string
-        contents: [{ //array of JSON objects, id and quantity are required fields
-                id: SKU, //array of intergers or strings (e.g. ['ABC123', 'XYZ789'])
-                quantity: QTY //interger or float
-            },
-            {
-                id: SKU,
-                quantity: QTY
-            }
-        ]
+        'fbParameterObject': {
+            value: basketValue,         // interger or float of the total basket value
+            currency: currencyXYZ,      // 3-letter currrency code as a string 'MYR' or 'USD' etc
+            content_type: 'product',    // required parameter
+            content_ids: arrayOfSKUs    // product IDs (or SKU's) associated with the event stored in an array e.g. ['ABC123', 'XYZ789']
+        },
+        'event': eventName
     });
-}
-
-function vid1_a() {
-    pushTracking("General Play Video Click", "Site Interactions");
+    console.log("event:",eventName, "with dynamic product parameters pushed successfully to the dataLayer");
 }


### PR DESCRIPTION
I took the liberty of revising the function that you already finished nicely. According to the fb documentation, we are to choose either `content_ids` or `contents` when using dynamic ads parameters. I went with `content_ids` as I don't think we need to quantity of each id in every pixel call. 

Also, I did not fully understand the SKU choices, single or multiple, so I simply forced the need for an array by using the above `content_ids` parameter.

Lastly, I placed all parameters inside an object called `fbParameterObject' to allow for direct insertion into the GTM custom facebook template, rather than fetching individual parameters through the dataLayer. Even the event name of the facebook pixel can now be fetched dynamically within GTM by using the "Event" variable. It will then look something like this when used.

![image](https://user-images.githubusercontent.com/477513/70863424-e9fb6e00-1f82-11ea-8fc4-af24377b09a8.png)
